### PR TITLE
feat: add entryUnicity option

### DIFF
--- a/src/config/default.js
+++ b/src/config/default.js
@@ -26,5 +26,6 @@ module.exports = {
     rights: {},
     getUserInfo(email) {
         return {email};
-    }
+    },
+    entryUnicity: 'byOwner' // can be byOwner or global
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,7 +28,10 @@ module.exports = {
     DESIGN_DOC_VERSION: 22,
     RIGHTS_DOC_ID: 'rights',
     DEFAULT_GROUPS_DOC_ID: 'defaultGroups',
+
     globalRightTypes,
     globalAdminRightTypes,
-    allowedFirstLevelKeys
+    allowedFirstLevelKeys,
+
+    kEntryUnicity: Symbol('entryUnicity')
 };

--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,8 @@ class Couch {
         this._administrators = config.administrators || [];
         this._superAdministrators = config.superAdministrators || [];
 
+        this[constants.kEntryUnicity] = config.entryUnicity || 'byOwner';
+
         this._nano = nano(this._couchOptions.url);
         this._db = null;
         this._lastAuth = 0;

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,6 +3,7 @@
 const Couch = require('..');
 const nanoPromise = require('../src/util/nanoPromise');
 const assert = require('assert');
+const entryUnicity = require('./data/entryUnicity');
 
 process.on('unhandledRejection', function (err) {
     throw err;
@@ -35,24 +36,22 @@ describe('basic initialization tests', function () {
 });
 
 describe('basic initialization with custom design docs', function () {
-    let couch;
-    it('should load the design doc files at initialization', function () {
-        couch = Couch.get('test3');
-        return couch._initPromise.then(function () {
-            var app = nanoPromise.getDocument(couch._db, '_design/app')
-                .then(app => {
-                    assert.notEqual(app, null);
-                    assert.ok(app.views.test);
-                    assert.ok(app.filters.abc);
-                });
-            var custom = nanoPromise.getDocument(couch._db, '_design/custom')
-                .then(custom => {
-                    assert.notEqual(custom, null);
-                    assert.ok(custom.views.testCustom);
-                });
+    beforeEach(entryUnicity);
 
-            return Promise.all([app, custom]);
-        });
+    it('should load the design doc files at initialization', function () {
+        const app = nanoPromise.getDocument(couch._db, '_design/app')
+            .then(app => {
+                assert.notEqual(app, null);
+                assert.ok(app.views.test);
+                assert.ok(app.filters.abc);
+            });
+        const custom = nanoPromise.getDocument(couch._db, '_design/custom')
+            .then(custom => {
+                assert.notEqual(custom, null);
+                assert.ok(custom.views.testCustom);
+            });
+
+        return Promise.all([app, custom]);
     });
 
     it('should query a custom design document', function () {

--- a/test/data/entryUnicity.js
+++ b/test/data/entryUnicity.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const Couch = require('../..');
+const nanoPromise = require('../../src/util/nanoPromise');
+const insertDocument = require('./insertDocument');
+
+function destroy(nano, name) {
+    return nanoPromise.destroyDatabase(nano, name);
+}
+
+function populate(db) {
+    const prom = [];
+
+    prom.push(insertDocument(db, {
+        $type: 'entry',
+        $owners: ['b@b.com', 'groupA', 'groupB'],
+        $id: 'A',
+        $content: {}
+    }));
+
+    return Promise.all(prom);
+}
+
+module.exports = function () {
+    global.couch = new Couch({database: 'test3'});
+    return global.couch.open()
+        .then(() => destroy(global.couch._nano, global.couch._databaseName))
+        .then(() => {
+            global.couch = new Couch({
+                database: 'test3',
+                rights: {
+                    create: ['anyuser']
+                }
+            });
+            return global.couch.open();
+        })
+        .then(() => populate(global.couch._db));
+};

--- a/test/entryUnicity.js
+++ b/test/entryUnicity.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const entryUnicity = require('./data/entryUnicity');
+
+describe('global entry unicity', function () {
+    beforeEach(entryUnicity);
+    it('createEntry should fail', function () {
+        return couch.createEntry('A', 'a@a.com', {throwIfExists: true}).should.be.rejectedWith(/entry already exists/);
+    });
+
+    it('insertEntry should fail', function () {
+        return couch.insertEntry({$id: 'A', $content: {}}, 'a@a.com').should.be.rejectedWith(/entry already exists/);
+    });
+});

--- a/test/homedir/test3/config.js
+++ b/test/homedir/test3/config.js
@@ -9,12 +9,16 @@ module.exports = {
             },
             test: {
                 map: function (doc) {
-                    emit(doc._id);
+                    if (doc.$type === 'entry') {
+                        emit(doc._id);
+                    }
                 }
             },
             testCustom: {
                 map: function (doc) {
-                    emit(doc._id);
+                    if (doc.$type === 'entry') {
+                        emit(doc._id);
+                    }
                 },
                 designDoc: 'custom'
             }
@@ -25,5 +29,6 @@ module.exports = {
                 return doc.$type === 'log';
             }
         }
-    }
+    },
+    entryUnicity: 'global'
 };


### PR DESCRIPTION
Defaults to 'byOwner' (current behavior) and can be set to 'global'.
When set to 'global', there cannot be two entries with the same id
by different owners.