### PR TITLE
Soft delete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4604,8 +4604,7 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "json-schema": {
           "version": "0.2.3",

--- a/src/couch/entry.js
+++ b/src/couch/entry.js
@@ -62,8 +62,9 @@ const methods = {
 
   async deleteEntry(uuid, user) {
     debug(`deleteEntry (${uuid}, ${user})`);
-    await this.getEntryWithRights(uuid, user, 'delete');
-    return nanoPromise.destroyDocument(this._db, uuid);
+    const entry = await this.getEntryWithRights(uuid, user, 'delete');
+    entry._deleted = true;
+    return nanoMethods.saveEntry(this._db, entry, user);
   },
 
   // Create entry if does not exist


### PR DESCRIPTION
add couch and rest api for a soft delete

This allows to keep the entire document instead of just the id and revision.