### PR TITLE
Patch get user groups

### DIFF
--- a/src/couch/user.js
+++ b/src/couch/user.js
@@ -5,6 +5,8 @@ const debug = require('../util/debug')('main:user');
 const nanoPromise = require('../util/nanoPromise');
 const simpleMerge = require('../util/simpleMerge');
 
+const validate = require('./validate');
+
 const methods = {
   async editUser(user, data) {
     debug(`editUser (${user})`);
@@ -39,10 +41,13 @@ const methods = {
 
   async getUserGroups(user) {
     await this.open();
-    const groups = await nanoPromise.queryView(this._db, 'groupByUser', {
+    let groups = await nanoPromise.queryView(this._db, 'groupByUser', {
       key: user
     });
-    return groups.map((doc) => doc.value);
+    groups = groups.map((doc) => doc.value);
+    // Add default groups
+    const defaultGroups = await validate.getDefaultGroups(this._db, user, true);
+    return groups.concat(defaultGroups);
   }
 };
 

--- a/src/util/nanoPromise.js
+++ b/src/util/nanoPromise.js
@@ -28,7 +28,10 @@ exports.getDatabase = function (nano, database) {
     debug.trace(`getDatabase ${database}`);
     nano.db.get(database, (err) => {
       if (err) {
-        if (err.reason === 'no_db_file') {
+        if (
+          err.reason === 'no_db_file' /* couchdb 1.6 */ ||
+          err.reason === 'Database does not exist.' /* couchdb 2.x.x */
+        ) {
           debug.trace('database not found');
           return resolve(false);
         }

--- a/test/group.js
+++ b/test/group.js
@@ -96,6 +96,11 @@ describe('group methods', () => {
       expect(docs).toHaveLength(0);
     });
   });
+
+  test('should get list of groups user is member of', async function () {
+    const users = await couch.getUserGroups('a@a.com');
+    expect(users.map((g) => g.name).sort()).toEqual(['groupA', 'groupB']);
+  });
 });
 
 describe('group methods (no default rights)', () => {
@@ -105,5 +110,16 @@ describe('group methods (no default rights)', () => {
     return expect(couch.createGroup('groupX', 'a@a.com')).rejects.toThrow(
       /does not have createGroup right/
     );
+  });
+
+  test('should get list of groups user is member of, including default groups', async function () {
+    let groups = await couch.getUserGroups('a@a.com');
+    groups.sort((a, b) => b.name < a.name);
+    expect(groups).toEqual([
+      { name: 'defaultAnonymousRead', rights: ['read'] },
+      { name: 'defaultAnyuserRead', rights: ['read'] },
+      { name: 'groupA', rights: ['create', 'write', 'delete', 'read'] },
+      { name: 'inexistantGroup', rights: [] }
+    ]);
   });
 });


### PR DESCRIPTION
@targos 
This really patches the getUserGroups method. Previously if a group had no users but was in the default groups, this method would not return it as part of the user's group.

This pull request also fixes a compatibility problem between couchdb 1 and 2. nano does not return the same `reason` when a database does not exist.

