### PR TITLE
5.7.0

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,13 @@
+<a name="5.7.0"></a>
+# [5.7.0](https://github.com/cheminfo/rest-on-couch/compare/v5.6.1...v5.7.0) (2018-08-13)
+
+
+### Features
+
+* **config:** custom views can be put in a special views folder in multiple files ([3e08f77](https://github.com/cheminfo/rest-on-couch/commit/3e08f77))
+
+
+
 <a name="5.6.1"></a>
 ## [5.6.1](https://github.com/cheminfo/rest-on-couch/compare/v5.6.0...v5.6.1) (2018-05-25)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-on-couch",
-  "version": "5.6.1",
+  "version": "5.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-on-couch",
-  "version": "5.6.1",
+  "version": "5.7.0",
   "description":
     "Interface to CouchDB that allows the control of permissions on the documents",
   "main": "src/index.js",


### PR DESCRIPTION
I tried to publish with `cheminfo publish` but of course the push failed.

Should we use npm publish after the pull request has been merged instead?
And push the tag manually?

@targos 