### PR TITLE
fix: allow to configure SameSite session cookie option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Type: boolean
 Default: `false`  
 Set to `true` if the cookie should only be valid on secure URLs.
 
+#### sessionSameSite
+
+Type: string
+Default: `'lax'`
+Value of the ["SameSite"](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) cookie option. Set to `'strict'`, `'lax'`, or `'none'`.
+
 #### debugrest
 
 Type: boolean  
@@ -168,9 +174,9 @@ attachment is to be added
 function zenodoAttachments(content) {
   if (content.general && content.general.molfile) {
     return {
-      filename: "molfile.mol",
-      contentType: "chemical/x-mdl-molfile",
-      data: content.general.molfile
+      filename: 'molfile.mol',
+      contentType: 'chemical/x-mdl-molfile',
+      data: content.general.molfile,
     };
   }
 }

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -26,6 +26,7 @@ module.exports = {
   sessionPath: '/',
   sessionSecure: false,
   sessionSigned: true,
+  sessionSameSite: 'lax',
 
   allowedOrigins: [],
   debugrest: false,

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -83,6 +83,7 @@ app.use(
       secure: config.sessionSecure,
       httpOnly: true,
       signed: config.sessionSigned,
+      sameSite: config.sessionSameSite,
     },
     app,
   ),


### PR DESCRIPTION
This is required since recent versions of Chrome to have a working cross-origin cookie.