### PR TITLE
[WIP] Allow users to provide ORCID for Zenodo export 

### DIFF
--- a/src/roc-zenodo/getZenodoDeposition.js
+++ b/src/roc-zenodo/getZenodoDeposition.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const okORCID = require('../util/orcid');
+const okOrcid = require('../util/orcid');
 
 function getZenodoDeposition(entry, self) {
   const result = {
@@ -70,7 +70,7 @@ function validateCreators(creators) {
       throw new TypeError('creator must have an affiliation');
     }
     if (orcid in creator) {
-      if (okORCID(creator.orcid)) {
+      if (okOrcid(creator.orcid)) {
         toReturn.push({
           name: creatorName,
           affiliation: creator.affiliation,

--- a/src/roc-zenodo/getZenodoDeposition.js
+++ b/src/roc-zenodo/getZenodoDeposition.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const okORCID = require('../util/orcid');
+
 function getZenodoDeposition(entry, self) {
   const result = {
     metadata: {
@@ -67,10 +69,22 @@ function validateCreators(creators) {
     if (typeof creator.affiliation !== 'string') {
       throw new TypeError('creator must have an affiliation');
     }
-    toReturn.push({
-      name: creatorName,
-      affiliation: creator.affiliation,
-    });
+    if (orcid in creator) {
+      if (okORCID(creator.orcid)) {
+        toReturn.push({
+          name: creatorName,
+          affiliation: creator.affiliation,
+          orcid: creator.orcid,
+        });
+      } else {
+        throw new TypeError('Not a valid ORCID identifier');
+      }
+    } else {
+      toReturn.push({
+        name: creatorName,
+        affiliation: creator.affiliation,
+      });
+    }
   }
   return toReturn;
 }

--- a/src/util/orcid.js
+++ b/src/util/orcid.js
@@ -1,32 +1,32 @@
-function generateCheckDigit(noHyphenORCID) {
+function generateCheckDigit(noHyphenOrcid) {
   // Generates check digit as per ISO 7064 11,2 for 15 digit string
   // http://support.orcid.org/knowledgebase/articles/116780-structure-of-the-orcid-identifier
   let total = 0;
   let zero = '0'.charCodeAt(0);
   for (let i = 0; i < 15; i++) {
-    let digit = noHyphenORCID.charCodeAt(i) - zero;
+    let digit = noHyphenOrcid.charCodeAt(i) - zero;
     total = (total + digit) * 2;
   }
   let result = (12 - (total % 11)) % 11;
   return result == 10 ? 'X' : String(result);
 }
 
-function okORCID(orcid) {
+function okOrcid(orcid) {
   if (typeof orcid !== 'string') {
     return false;
   }
-  let noHyphenORCID = orcid.replace(
+  let noHyphenOrcid = orcid.replace(
     /^(\d{4})-(\d{4})-(\d{4})-(\d\d\d[\dX])$/,
     '$1$2$3$4',
   );
-  if (noHyphenORCID == orcid) {
+  if (noHyphenOrcid == orcid) {
     // will not match if replace succeeded
     return false;
   }
-  if (noHyphenORCID.charAt(15) != generateCheckDigit(noHyphenORCID)) {
+  if (noHyphenOrcid.charAt(15) != generateCheckDigit(noHyphenOrcid)) {
     return false;
   }
   return true;
 }
 
-module.exports = okORCID;
+module.exports = okOrcid;

--- a/src/util/orcid.js
+++ b/src/util/orcid.js
@@ -1,0 +1,32 @@
+function generateCheckDigit(noHyphenORCID) {
+  // Generates check digit as per ISO 7064 11,2 for 15 digit string
+  // http://support.orcid.org/knowledgebase/articles/116780-structure-of-the-orcid-identifier
+  let total = 0;
+  let zero = '0'.charCodeAt(0);
+  for (let i = 0; i < 15; i++) {
+    let digit = noHyphenORCID.charCodeAt(i) - zero;
+    total = (total + digit) * 2;
+  }
+  let result = (12 - (total % 11)) % 11;
+  return result == 10 ? 'X' : String(result);
+}
+
+function okORCID(orcid) {
+  if (typeof orcid !== 'string') {
+    return false;
+  }
+  let noHyphenORCID = orcid.replace(
+    /^(\d{4})-(\d{4})-(\d{4})-(\d\d\d[\dX])$/,
+    '$1$2$3$4',
+  );
+  if (noHyphenORCID == orcid) {
+    // will not match if replace succeeded
+    return false;
+  }
+  if (noHyphenORCID.charAt(15) != generateCheckDigit(noHyphenORCID)) {
+    return false;
+  }
+  return true;
+}
+
+module.exports = okORCID;

--- a/test/unit/orcid.js
+++ b/test/unit/orcid.js
@@ -1,0 +1,8 @@
+const okORCID = require('../../src/util/orcid');
+
+it('test ORCID checksum calculation', () => {
+  expect(okORCID('0000-0003-4894-4660')).toBe(true);
+  expect(okORCID(undefined)).toBe(false);
+  expect(okORCID(39070)).toBe(false);
+  expect(okORCID('0000-0003-4894-4661')).toBe(false);
+});


### PR DESCRIPTION
The Zenodo API allows to also provide the ORCID for the creators (https://developers.zenodo.org/#depositions). 

This PR checks for the field and and checks if the ORCID is a valid one. 

I'm not sure what the best way to test this is though and if you're fine with where I placed the files. 