### PR TITLE
chore: throttle attachment uploads

### DIFF
--- a/src/server/middleware/zenodo.js
+++ b/src/server/middleware/zenodo.js
@@ -214,7 +214,7 @@ async function publish(
           userEmail,
           true,
         );
-        await delay(60);
+        await delay(600);
         await rocZenodo.uploadFile(deposition, {
           filename: `${filenamePrefix}/${attachmentPath}`,
           contentType,

--- a/src/server/middleware/zenodo.js
+++ b/src/server/middleware/zenodo.js
@@ -1,9 +1,9 @@
 'use strict';
 
+const delay = require('delay');
 const config = require('../../config/config').globalConfig;
 const debug = require('../../util/debug')('zenodo');
 const { RocZenodo } = require('../../roc-zenodo');
-
 const { decorateError } = require('./decorateError');
 const { composeWithError } = require('./util');
 
@@ -214,6 +214,7 @@ async function publish(
           userEmail,
           true,
         );
+        await delay(60);
         await rocZenodo.uploadFile(deposition, {
           filename: `${filenamePrefix}/${attachmentPath}`,
           contentType,


### PR DESCRIPTION
the Zenodo API limits to 5000 requests / h and in the sandbox we received and error with maximum 100 requests / min. 
@lpatiny suggested to simply use a delay. 

