### PR TITLE
feat: added support for ORCID id of creator in Zenodo submission

### DIFF
--- a/src/roc-zenodo/getZenodoDeposition.js
+++ b/src/roc-zenodo/getZenodoDeposition.js
@@ -79,7 +79,7 @@ function validateCreators(creators) {
       if (okOrcid(creator.orcid)) {
         creatorToReturn.orcid = creator.orcid;
       } else {
-        throw new TypeError('Not a valid ORCID identifier');
+        throw new TypeError(`${creator.orcid} is not a valid ORCID identifier`);
       }
     }
     toReturn.push(creatorToReturn);

--- a/src/roc-zenodo/getZenodoDeposition.js
+++ b/src/roc-zenodo/getZenodoDeposition.js
@@ -69,22 +69,20 @@ function validateCreators(creators) {
     if (typeof creator.affiliation !== 'string') {
       throw new TypeError('creator must have an affiliation');
     }
+
+    const creatorToReturn = {
+      name: creatorName,
+      affiliation: creator.affiliation,
+    };
+
     if ('orcid' in creator) {
       if (okOrcid(creator.orcid)) {
-        toReturn.push({
-          name: creatorName,
-          affiliation: creator.affiliation,
-          orcid: creator.orcid,
-        });
+        creatorToReturn.orcid = creator.orcid;
       } else {
         throw new TypeError('Not a valid ORCID identifier');
       }
-    } else {
-      toReturn.push({
-        name: creatorName,
-        affiliation: creator.affiliation,
-      });
     }
+    toReturn.push(creatorToReturn);
   }
   return toReturn;
 }

--- a/src/roc-zenodo/getZenodoDeposition.js
+++ b/src/roc-zenodo/getZenodoDeposition.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const okOrcid = require('../util/orcid');
+
 function getZenodoDeposition(entry, self) {
   const result = {
     metadata: {
@@ -67,10 +69,22 @@ function validateCreators(creators) {
     if (typeof creator.affiliation !== 'string') {
       throw new TypeError('creator must have an affiliation');
     }
-    toReturn.push({
-      name: creatorName,
-      affiliation: creator.affiliation,
-    });
+    if ('orcid' in creator) {
+      if (okOrcid(creator.orcid)) {
+        toReturn.push({
+          name: creatorName,
+          affiliation: creator.affiliation,
+          orcid: creator.orcid,
+        });
+      } else {
+        throw new TypeError('Not a valid ORCID identifier');
+      }
+    } else {
+      toReturn.push({
+        name: creatorName,
+        affiliation: creator.affiliation,
+      });
+    }
   }
   return toReturn;
 }

--- a/src/util/orcid.js
+++ b/src/util/orcid.js
@@ -1,0 +1,33 @@
+'use strict';
+
+function generateCheckDigit(noHyphenOrcid) {
+  // https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier
+  let total = 0;
+  let zero = '0'.charCodeAt(0);
+  for (let i = 0; i < 15; i++) {
+    let digit = noHyphenOrcid.charCodeAt(i) - zero;
+    total = (total + digit) * 2;
+  }
+  let result = (12 - (total % 11)) % 11;
+  return result === 10 ? 'X' : String(result);
+}
+
+function okOrcid(orcid) {
+  // based on https://github.com/zimeon/orcid-feed-js
+  if (typeof orcid !== 'string') {
+    return false;
+  }
+  let noHyphenOrcid = orcid.replace(
+    /^(\d{4})-(\d{4})-(\d{4})-(\d\d\d[\dX])$/,
+    '$1$2$3$4',
+  );
+  if (noHyphenOrcid === orcid) {
+    return false;
+  }
+  if (noHyphenOrcid.charAt(15) !== generateCheckDigit(noHyphenOrcid)) {
+    return false;
+  }
+  return true;
+}
+
+module.exports = okOrcid;

--- a/test/unit/orcid.js
+++ b/test/unit/orcid.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const okORCID = require('../../src/util/orcid');
+
+it('test ORCID checksum calculation', () => {
+  expect(okORCID('0000-0003-4894-4660')).toBe(true);
+  expect(okORCID(undefined)).toBe(false);
+  expect(okORCID(39070)).toBe(false);
+  expect(okORCID('0000-0003-4894-4661')).toBe(false);
+});


### PR DESCRIPTION
The [Zenodo API supports the ORCID id of the creator](https://developers.zenodo.org/#depositions). 

This PR adds support for this optional field and checks if the ORCID is valid. 

I do not know though what the best way to test this is / I didn't see a test for the Zenodo submission. 
