### PR TITLE
feat(api): allow to set rights for entry token

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ docker start couchdb
 docker ps # check that the container is running
 ```
 
-(alternatively, `docker-compose  up --file docker-compose.dev.yml -d`)
+Alternatively: `docker-compose up --file docker-compose.dev.yml -d`
 
 Go to http://localhost:5984/_utils/#setup
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ function zenodoAttachments(content) {
 ```bash
 docker pull couchdb
 docker create -p 5984:5984 --name couchdb couchdb
-docker start couchdb 
+docker start couchdb
 docker ps # check that the container is running
 ```
 

--- a/README.md
+++ b/README.md
@@ -182,14 +182,16 @@ function zenodoAttachments(content) {
 }
 ```
 
-## Setup environment with Docker (for runnings tests)
+## Setup environment with Docker (for running tests)
 
 ```bash
 docker pull couchdb
 docker create -p 5984:5984 --name couchdb couchdb
-docker start couchdb
+docker start couchdb 
 docker ps # check that the container is running
 ```
+
+(alternatively, `docker-compose  up --file docker-compose.dev.yml -d`)
 
 Go to http://localhost:5984/_utils/#setup
 

--- a/src/couch/token.js
+++ b/src/couch/token.js
@@ -7,15 +7,16 @@ const token = require('../util/token');
 const { isValidUsername, ensureRightsArray } = require('./util');
 
 const methods = {
-  async createEntryToken(user, uuid) {
+  async createEntryToken(user, uuid, rights = ['read']) {
     debug('createEntryToken (%s, %s)', user, uuid);
     if (!isValidUsername(user)) {
       throw new CouchError('only a user can create a token', 'unauthorized');
     }
+    ensureRightsArray(rights);
     await this.open();
     // We need write right to create a token. This will throw if not.
     await this.getEntryWithRights(uuid, user, 'write');
-    return token.createEntryToken(this._db, user, uuid, 'read');
+    return token.createEntryToken(this._db, user, uuid, rights);
   },
 
   async createUserToken(user, rights = ['read']) {

--- a/src/server/middleware/couch.js
+++ b/src/server/middleware/couch.js
@@ -449,9 +449,11 @@ exports.removeGlobalDefaultGroup = composeWithError(async (ctx) => {
 });
 
 exports.createEntryToken = composeWithError(async (ctx) => {
+  const rights = ctx.query.rights ? ctx.query.rights.split(',') : 'read';
   const token = await ctx.state.couch.createEntryToken(
     ctx.state.userEmail,
     ctx.params.uuid,
+    rights,
   );
   ctx.status = 201;
   ctx.body = token;

--- a/test/unit/token.js
+++ b/test/unit/token.js
@@ -10,8 +10,10 @@ describe('token methods', () => {
     const tokens = await Promise.all([
       couch.createEntryToken('b@b.com', 'A'),
       couch.createEntryToken('b@b.com', 'B'),
+      couch.createEntryToken('b@b.com', 'B', ['read', 'write']),
     ]);
     expect(tokens[0].$id).not.toBe(tokens[1].$id);
+    expect(tokens[0].$id).not.toBe(tokens[2].$id);
     const token = tokens[0];
     expect(token.$type).toBe('token');
     expect(token.$kind).toBe('entry');
@@ -20,11 +22,19 @@ describe('token methods', () => {
     expect(token.uuid).toBe('A');
     expect(token.rights).toEqual(['read']);
 
+    const writeToken = tokens[2];
+    expect(writeToken.$type).toBe('token');
+    expect(writeToken.$kind).toBe('entry');
+    expect(writeToken.$id.length).toBe(32);
+    expect(writeToken.$owner).toBe('b@b.com');
+    expect(writeToken.uuid).toBe('B');
+    expect(writeToken.rights).toEqual(['read', 'write']);
+
     const gotToken = await couch.getToken(token.$id);
     expect(gotToken.$id).toBe(token.$id);
 
     const allTokens = await couch.getTokens('b@b.com');
-    expect(allTokens.length).toBe(2);
+    expect(allTokens.length).toBe(3);
   });
 
   test('user should be able to create and destroy tokens', async () => {
@@ -86,5 +96,9 @@ describe('token methods', () => {
     await expect(
       couch.createUserToken('a@a.com', ['read', 'test2']),
     ).rejects.toThrow('invalid right: test2');
+
+    await expect(
+      couch.createEntryToken('a@a.com', 'A', 'test1'),
+    ).rejects.toThrow('invalid right: test1');
   });
 });


### PR DESCRIPTION
we're trying to couple the ELN with some simulation services such as [AiiDAlab](https://aiidalab.materialscloud.org/). For that it would be great to create tokens that also give write access to entries (to put simulation results back into the ELN and close the provenance chain). 

in addition to that i made one minor change to the readme and hint also to the docker compose file which is slightly more convenient than running all the docker commands. 