### PR TITLE
fix: adding addAttachment into globalRightsTypes (do not merge) 

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,7 @@ const globalRightTypes = [
   'createGroup',
   'readImport',
   'owner',
+  'addAttachment',
 ];
 
 // administrators only have these rights


### PR DESCRIPTION
I think it should be set as 

https://github.com/cheminfo/rest-on-couch/blob/eea3faaa51cd4ffd4123c6cb2785cc50e7cecfe6/src/couch/attachment.js#L10-L36 checks for it. 

In the test it was set for `anyUser` (https://github.com/cheminfo/rest-on-couch/blob/eea3faaa51cd4ffd4123c6cb2785cc50e7cecfe6/test/data/data.js#L94-L106) so it was fine. But, for example, for samples that i own on c6h6.org i do not have this right (`_rights/addAttachment` yields `false` and also my `PUT` requests fail). 