### PR TITLE
feat: add addAttachment to globalRightsTypes

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -11,6 +11,7 @@ const globalRightTypes = [
   'createGroup',
   'readImport',
   'owner',
+  'addAttachment',
 ];
 
 // administrators only have these rights

--- a/test/unit/token.js
+++ b/test/unit/token.js
@@ -53,6 +53,23 @@ describe('token methods', () => {
     });
   });
 
+  test('user should be able to create a user token with rights', async () => {
+    const token = await couch.createUserToken('b@b.com', [
+      'read',
+      'addAttachment',
+    ]);
+    expect(token.$id).toMatch(testUtils.tokenReg);
+    expect(token.$creationDate).toBeGreaterThan(0);
+    delete token.$id;
+    delete token.$creationDate;
+    expect(token).toEqual({
+      $type: 'token',
+      $kind: 'user',
+      $owner: 'b@b.com',
+      rights: ['read', 'addAttachment'],
+    });
+  });
+
   test('token should give read access to non public data', async () => {
     const token = await couch.createUserToken('b@b.com');
     await expect(couch.getEntryById('A', 'a@a.com')).rejects.toThrow(


### PR DESCRIPTION
this allows to create tokens with the addAttachment rights (see the added unit test which failed before making this change)

the better version of https://github.com/cheminfo/rest-on-couch/pull/249 