### PR TITLE
fix: token authentication for API requests 

### DIFF
--- a/src/couch/attachment.js
+++ b/src/couch/attachment.js
@@ -8,7 +8,7 @@ const debug = require('../util/debug')('main:attachment');
 const nanoMethods = require('./nano');
 
 const methods = {
-  async addAttachments(uuid, user, attachments) {
+  async addAttachments(uuid, user, attachments, options) {
     let entry;
     if (typeof uuid === 'object') {
       entry = uuid;
@@ -19,22 +19,26 @@ const methods = {
       attachments = [attachments];
     }
     // This acts as a rights check.
-    const dbEntry = await this.getEntryWithRights(uuid, user, [
-      'write',
-      'addAttachment',
-    ]);
+    const dbEntry = await this.getEntryWithRights(
+      uuid,
+      user,
+      ['write', 'addAttachment'],
+      options,
+    );
     if (!entry) {
       entry = dbEntry;
     }
     return this._db.attachFiles(entry, attachments);
   },
 
-  async deleteAttachment(uuid, user, attachmentName) {
+  async deleteAttachment(uuid, user, attachmentName, options) {
     debug('deleteAttachment (%s, %s)', uuid, user);
-    const entry = await this.getEntryWithRights(uuid, user, [
-      'delete',
-      'addAttachment',
-    ]);
+    const entry = await this.getEntryWithRights(
+      uuid,
+      user,
+      ['delete', 'addAttachment'],
+      options,
+    );
     if (!entry._attachments[attachmentName]) {
       return false;
     }

--- a/src/couch/entry.js
+++ b/src/couch/entry.js
@@ -11,7 +11,7 @@ const validateMethods = require('./validate');
 
 const methods = {
   async getEntryWithRights(uuid, user, rights, options = {}) {
-    debug('getEntryWithRights (%s, %s, %o, %o)', uuid, user, rights, options);
+    debug('getEntryWithRights (%s, %s, %o)', uuid, user, rights);
     await this.open();
 
     const doc = await this._db.getDocument(uuid);
@@ -24,7 +24,7 @@ const methods = {
       throw new CouchError('document is not an entry', 'not entry');
     }
 
-    debug.trace('check rights for user %s token %o', user, options.token);
+    debug.trace('check rights for user %s', user);
     if (
       await validateMethods.validateTokenOrRights(
         this,

--- a/src/couch/entry.js
+++ b/src/couch/entry.js
@@ -11,7 +11,7 @@ const validateMethods = require('./validate');
 
 const methods = {
   async getEntryWithRights(uuid, user, rights, options = {}) {
-    debug('getEntryWithRights (%s, %s, %o)', uuid, user, rights);
+    debug('getEntryWithRights (%s, %s, %o, %o)', uuid, user, rights, options);
     await this.open();
 
     const doc = await this._db.getDocument(uuid);
@@ -24,7 +24,7 @@ const methods = {
       throw new CouchError('document is not an entry', 'not entry');
     }
 
-    debug.trace('check rights');
+    debug.trace('check rights for user %s token %o', user, options.token);
     if (
       await validateMethods.validateTokenOrRights(
         this,

--- a/src/couch/validate.js
+++ b/src/couch/validate.js
@@ -97,17 +97,20 @@ async function validateTokenOrRights(
   type = 'entry',
 ) {
   rights = ensureStringArray(rights);
-
   if (token && token.$kind === 'user') {
+    debug.trace('user token right validation');
     if (!areRightsInToken(rights, token)) {
+      debug.trace('user token that does not have sufficient rights');
       return false;
     }
     user = token.$owner;
   }
 
   if (token && token.$kind === type && token.uuid === uuid) {
+    debug.trace('entry token right validation');
     for (var i = 0; i < rights.length; i++) {
       if (!token.rights.includes(rights[i])) {
+        debug.trace('entry token does not have sufficient rights');
         return false;
       }
     }

--- a/src/server/middleware/couch.js
+++ b/src/server/middleware/couch.js
@@ -18,7 +18,7 @@ const couchNeedsParse = ['key', 'startkey', 'endkey'];
 const invalidDbName = 'invalid database name';
 exports.setupCouch = async (ctx, next) => {
   const dbname = ctx.params.dbname;
-  debug('setting up couch with db', dbname);
+  debug.trace('setting up couch with db', dbname);
   ctx.state.dbName = dbname;
   try {
     ctx.state.couch = Couch.get(dbname);
@@ -32,7 +32,7 @@ exports.setupCouch = async (ctx, next) => {
   ctx.state.userEmail = ctx.query.asAnonymous
     ? 'anonymous'
     : await auth.getUserEmail(ctx);
-  debug('user email set to', ctx.state.userEmail);
+  debug.trace('user email set to', ctx.state.userEmail);
   processCouchQuery(ctx);
   await next();
 };
@@ -124,6 +124,7 @@ exports.deleteAttachment = composeWithError(async (ctx) => {
     ctx.params.uuid,
     ctx.state.userEmail,
     ctx.params.attachment,
+    { token: ctx.query.token },
   );
 });
 
@@ -136,6 +137,7 @@ exports.saveAttachment = composeWithError(async (ctx) => {
       data: ctx.request.body,
       content_type: ctx.get('Content-Type'),
     },
+    { token: ctx.query.token },
   );
 });
 

--- a/src/server/middleware/couch.js
+++ b/src/server/middleware/couch.js
@@ -18,18 +18,21 @@ const couchNeedsParse = ['key', 'startkey', 'endkey'];
 const invalidDbName = 'invalid database name';
 exports.setupCouch = async (ctx, next) => {
   const dbname = ctx.params.dbname;
+  debug('setting up couch with db', dbname);
   ctx.state.dbName = dbname;
-  ctx.state.userEmail = ctx.query.asAnonymous
-    ? 'anonymous'
-    : await auth.getUserEmail(ctx);
   try {
     ctx.state.couch = Couch.get(dbname);
   } catch (e) {
+    debug('error setting up couch', e);
     if (e.message === invalidDbName) {
       onGetError(ctx, new CouchError(invalidDbName, 'forbidden'));
       return;
     }
   }
+  ctx.state.userEmail = ctx.query.asAnonymous
+    ? 'anonymous'
+    : await auth.getUserEmail(ctx);
+  debug('user email set to', ctx.state.userEmail);
   processCouchQuery(ctx);
   await next();
 };

--- a/test/data/data.js
+++ b/test/data/data.js
@@ -104,7 +104,7 @@ function populate(db) {
       $owner: 'b@b.com',
       $id: 'myReadOnlyToken',
       $creationDate: 0,
-      uuid: 'A',
+      uuid: 'documentOfA',
       rights: ['read'],
     }),
   );
@@ -116,8 +116,8 @@ function populate(db) {
       $owner: 'b@b.com',
       $id: 'myAddAttachmentToken',
       $creationDate: 0,
-      uuid: 'A',
-      rights: ['read', 'addAttachment'],
+      uuid: 'documentOfA',
+      rights: ['read', 'addAttachment', 'write'],
     }),
   );
 

--- a/test/data/data.js
+++ b/test/data/data.js
@@ -29,6 +29,15 @@ function populate(db) {
     }),
   );
 
+  prom.push(
+    insertDocument(db, {
+      $type: 'entry',
+      $owners: ['a@a.com'],
+      $id: 'documentOfA',
+      $content: {},
+    }),
+  );
+
   // Add users
   prom.push(
     insertDocument(db, {
@@ -85,6 +94,30 @@ function populate(db) {
           data: 'VEhJUyBJUyBBIFRFU1Q=',
         },
       },
+    }),
+  );
+
+  prom.push(
+    insertDocument(db, {
+      $type: 'token',
+      $kind: 'entry',
+      $owner: 'b@b.com',
+      $id: 'myReadOnlyToken',
+      $creationDate: 0,
+      uuid: 'A',
+      rights: ['read'],
+    }),
+  );
+
+  prom.push(
+    insertDocument(db, {
+      $type: 'token',
+      $kind: 'entry',
+      $owner: 'b@b.com',
+      $id: 'myAddAttachmentToken',
+      $creationDate: 0,
+      uuid: 'A',
+      rights: ['read', 'addAttachment'],
     }),
   );
 

--- a/test/unit/entry.js
+++ b/test/unit/entry.js
@@ -46,7 +46,7 @@ describe('entry reads', () => {
     return couch
       .getEntriesByUserAndRights('b@b.com', 'read')
       .then((entries) => {
-        expect(entries).toHaveLength(5);
+        expect(entries).toHaveLength(6);
       });
   });
 });

--- a/test/unit/rest-api/user.js
+++ b/test/unit/rest-api/user.js
@@ -13,6 +13,31 @@ describe('User REST-api (data, anonymous)', () => {
   // TODO: save user as anonymous. What status code?
 });
 
+describe('User REST-api (token)', () => {
+  beforeEach(data);
+  test('Should be able to PUT', () => {
+    return request
+      .put('/db/test/entry/A/blub.txt?token=myAddAttachmentToken')
+      .set('Content-Type', 'text/plain')
+      .send('rest-on-couch!!')
+      .expect(200);
+  });
+
+  test('Should be able to PUT but not without the right in the token', () => {
+    return request
+      .put('/db/test/entry/A/blub.txt?token=myReadOnlyToken')
+      .set('Content-Type', 'text/plain')
+      .send('rest-on-couch!!')
+      .expect(200);
+  });
+
+  test('Should be able to GET with the token', () => {
+    return request
+      .get('/db/test/entry/A?token=myAddAttachmentToken')
+      .expect(200);
+  });
+});
+
 describe('User REST-api (data, a@a.com', () => {
   beforeEach(() => {
     return data().then(() => authenticateAs(request, 'a@a.com', '123'));

--- a/test/unit/rest-api/user.js
+++ b/test/unit/rest-api/user.js
@@ -17,7 +17,7 @@ describe('User REST-api (token)', () => {
   beforeEach(data);
   test('Should be able to PUT', () => {
     return request
-      .put('/db/test/entry/A/blub.txt?token=myAddAttachmentToken')
+      .put('/db/test/entry/documentOfA/blub.txt?token=myAddAttachmentToken')
       .set('Content-Type', 'text/plain')
       .send('rest-on-couch!!')
       .expect(200);
@@ -25,10 +25,10 @@ describe('User REST-api (token)', () => {
 
   test('Should be able to PUT but not without the right in the token', () => {
     return request
-      .put('/db/test/entry/A/blub.txt?token=myReadOnlyToken')
+      .put('/db/test/entry/documentOfA/blub.txt?token=myReadOnlyToken')
       .set('Content-Type', 'text/plain')
       .send('rest-on-couch!!')
-      .expect(200);
+      .expect(401);
   });
 
   test('Should be able to GET with the token', () => {


### PR DESCRIPTION
all `PUT` requests failed with unauthorized as the `getUserEmailFromToken` function always returned `anonymous`.  Now it checks for the owner of the token.

Test cases for requests using the tokens have been added.