### PR TITLE
fix: pass token also for the updateEntry route

### DIFF
--- a/src/couch/entry.js
+++ b/src/couch/entry.js
@@ -214,6 +214,8 @@ const methods = {
       );
     }
 
+    let token = options.token || null;
+
     if (entry._id && options.isNew) {
       debug.trace('new entry has _id');
       throw new CouchError('entry should not have _id', 'bad argument');
@@ -225,7 +227,9 @@ const methods = {
     let action = 'updated';
     if (entry._id) {
       try {
-        const doc = await this.getEntryWithRights(entry._id, user, ['write']);
+        const doc = await this.getEntryWithRights(entry._id, user, ['write'], {
+          token: token,
+        });
         result = await updateEntry(this, doc, entry, user, options);
       } catch (e) {
         if (e.reason === 'not found') {

--- a/src/couch/entry.js
+++ b/src/couch/entry.js
@@ -214,8 +214,6 @@ const methods = {
       );
     }
 
-    let token = options.token || null;
-
     if (entry._id && options.isNew) {
       debug.trace('new entry has _id');
       throw new CouchError('entry should not have _id', 'bad argument');
@@ -228,7 +226,7 @@ const methods = {
     if (entry._id) {
       try {
         const doc = await this.getEntryWithRights(entry._id, user, ['write'], {
-          token: token,
+          token: options.token,
         });
         result = await updateEntry(this, doc, entry, user, options);
       } catch (e) {

--- a/src/server/middleware/couch.js
+++ b/src/server/middleware/couch.js
@@ -89,6 +89,9 @@ exports.updateEntry = composeWithError(async (ctx) => {
   if (ctx.query.token) {
     options.token = ctx.query.token;
   }
+  if (ctx.query.merge) {
+    options.merge = ctx.query.merge;
+  }
   const result = await ctx.state.couch.insertEntry(
     body,
     ctx.state.userEmail,

--- a/src/server/middleware/couch.js
+++ b/src/server/middleware/couch.js
@@ -85,9 +85,15 @@ exports.getDocument = composeWithError(async (ctx) => {
 exports.updateEntry = composeWithError(async (ctx) => {
   const body = ctx.request.body;
   if (body) body._id = ctx.params.uuid;
-  const result = await ctx.state.couch.insertEntry(body, ctx.state.userEmail, {
-    isUpdate: true,
-  });
+  let options = { isUpdate: true };
+  if (ctx.query.token) {
+    options.token = ctx.query.token;
+  }
+  const result = await ctx.state.couch.insertEntry(
+    body,
+    ctx.state.userEmail,
+    options,
+  );
   assert.strictEqual(result.action, 'updated');
   ctx.body = result.info;
 });

--- a/test/data/data.js
+++ b/test/data/data.js
@@ -121,6 +121,17 @@ function populate(db) {
     }),
   );
 
+  prom.push(
+    insertDocument(db, {
+      $type: 'token',
+      $kind: 'user',
+      $owner: 'b@b.com',
+      $id: 'myUserToken',
+      $creationDate: 0,
+      rights: ['read', 'write', 'addAttachment'],
+    }),
+  );
+
   return Promise.all(prom);
 }
 

--- a/test/unit/rest-api/user.js
+++ b/test/unit/rest-api/user.js
@@ -36,6 +36,19 @@ describe('User REST-api (token)', () => {
       .get('/db/test/entry/A?token=myAddAttachmentToken')
       .expect(200);
   });
+
+  test('Should be able to update document with user token', () => {
+    return couch.getEntryById('A', 'b@b.com').then((entry) => {
+      return request
+        .put('/db/test/entry/A?token=myUserToken')
+        .send({ $id: 'A', $content: { something: 'new' }, _rev: entry._rev })
+        .expect(200)
+        .then((res) => {
+          expect(res.body).toHaveProperty('rev');
+          expect(res.body.rev).toMatch(/^2/);
+        });
+    });
+  });
 });
 
 describe('User REST-api (data, a@a.com', () => {


### PR DESCRIPTION
This time, I tried to make a simple update of the entry, e.g., 

a `PUT` to 
```
http://localhost:3000/db/test/entry/A?token=myUserToken
```

with 

```json
{
    "ok": true,
    "id": "A",
    "rev": "2-b5e45898a38082b584746bd8595e8606",
    "$modificationDate": 1614929449107,
    "$creationDate": 0
}
```

(see the new unit test). 

But it seems that it ran into the same issue that the token was not passed through to the `getEntriesByUserAndRights` function. 