### PR TITLE
fix: fail early when creating document with group but no owner right in token

### DIFF
--- a/src/couch/validate.js
+++ b/src/couch/validate.js
@@ -214,6 +214,7 @@ function areRightsInToken(rights, token) {
   if (rights.length > token.rights.length) {
     return false;
   }
+
   const tokenRights = new Set(token.rights);
   for (const right of rights) {
     if (!tokenRights.has(right)) {

--- a/test/unit/token.js
+++ b/test/unit/token.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const constants = require('../data/constants');
 const data = require('../data/noRights');
 const testUtils = require('../utils/testUtils');
 
@@ -80,13 +81,26 @@ describe('token methods', () => {
     });
   });
 
-  test('token should give read access to non public data', async () => {
+  test('user token should give read access to non public data', async () => {
     const token = await couch.createUserToken('b@b.com');
     await expect(couch.getEntryById('A', 'a@a.com')).rejects.toThrow(
       'document not found',
     );
     const entry = await couch.getEntry('A', 'a@a.com', { token });
     expect(entry).toBeDefined();
+  });
+
+  test('user token should not allow to create document if user cannot create', async () => {
+    const token = await couch.createUserToken('b@b.com', [
+      'read',
+      'write',
+      'create',
+    ]);
+    await expect(
+      couch.insertEntry(constants.newEntry, 'anonymous', {
+        token,
+      }),
+    ).rejects.toThrow('b@b.com not allowed to create');
   });
 
   test('token should give only the right for which it was created', async () => {

--- a/test/unit/token2.js
+++ b/test/unit/token2.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const constants = require('../data/constants');
+const data = require('../data/data');
+
+describe('token methods data', () => {
+  beforeEach(data);
+
+  test('user token allow to create document', async () => {
+    const token = await couch.createUserToken('a@a.com', [
+      'read',
+      'write',
+      'create',
+    ]);
+    const newEntry = await couch.insertEntry(constants.newEntry, 'anonymous', {
+      token,
+    });
+    expect(newEntry.action).toBe('created');
+    expect(newEntry.info.isNew).toBe(true);
+  });
+
+  test('user token should not allow to create document with groups if not owner', async () => {
+    const token = await couch.createUserToken('a@a.com', ['read', 'create']);
+    await expect(
+      couch.insertEntry(constants.newEntry, 'anonymous', {
+        token,
+        groups: ['group1'],
+      }),
+    ).rejects.toThrow(/not allowed to create with groups/);
+  });
+
+  test('user token allow to create document with groups if owner', async () => {
+    const token = await couch.createUserToken('a@a.com', [
+      'read',
+      'create',
+      'owner',
+    ]);
+    const newEntry = await couch.insertEntry(constants.newEntry, 'anonymous', {
+      token,
+      groups: ['group1'],
+    });
+    expect(newEntry.action).toBe('created');
+    expect(newEntry.info.isNew).toBe(true);
+  });
+});


### PR DESCRIPTION
previously the document would be created but it would not be possible to update owners with groups
