### PR TITLE
chore: use version reference in package overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "node": "16.14.2"
   },
   "overrides": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "$react",
+    "react-dom": "$react-dom"
   },
   "dependencies": {
     "@koa/router": "^10.1.1",


### PR DESCRIPTION
Avoids having to update this field when the dependencies are updated.
