### PR TITLE
fix: allow multiple entries with null $id

### DIFF
--- a/src/couch/entry.js
+++ b/src/couch/entry.js
@@ -290,9 +290,15 @@ async function _createNew(ctx, entry, user, options) {
   const hasGroups = options.groups ? options.groups.length > 0 : false;
   const rights = hasGroups ? ['create', 'owner'] : ['create'];
   user = validateMethods.userFromTokenAndRights(user, options.token, rights);
-  if (await getUniqueEntryById(ctx, user, entry.$id)) {
-    throw new CouchError('entry already exists', 'conflict');
+
+  // Exceptionally, if the $id is null, no unicity is enforced
+  // We keep this behavior for backward compatibility
+  if (entry.$id !== null) {
+    if (await getUniqueEntryById(ctx, user, entry.$id)) {
+      throw new CouchError('entry already exists', 'conflict');
+    }
   }
+
   const ok = await validateMethods.checkGlobalRight(ctx, user, 'create');
   const userSet = new Set(options.groups || []);
 

--- a/src/design/validateDocUpdate.js
+++ b/src/design/validateDocUpdate.js
@@ -113,6 +113,9 @@ module.exports = function (newDoc, oldDoc, userCtx) {
     validateDates(newDoc, oldDoc);
   } else if (newDoc.$type === 'entry') {
     validateOwners(newDoc);
+    if (newDoc.$id === undefined) {
+      throw { forbidden: '$id must be defined' };
+    }
     validateDates(newDoc, oldDoc);
     if (oldDoc) {
       if (Array.isArray(newDoc.$id) && Array.isArray(oldDoc.$id)) {

--- a/test/unit/design/validateDocUpdate.js
+++ b/test/unit/design/validateDocUpdate.js
@@ -17,6 +17,11 @@ describe('validate_doc_update', () => {
   describe('$type: entry', () => {
     test('id', () => {
       assert(
+        addOwners(addDate({ $type: 'entry' })),
+        null,
+        '$id must be defined',
+      );
+      assert(
         addOwners(addDate({ $type: 'entry', $id: 'abc' })),
         addOwners(addDate({ $type: 'entry', $id: 'xyz' })),
         'Cannot change the ID',

--- a/test/unit/entry.js
+++ b/test/unit/entry.js
@@ -349,6 +349,22 @@ describe('entry creation and editions', () => {
       'entry already exists',
     ]);
   });
+
+  test('multiple entries with an $id of null can be created by the same user', async () => {
+    const entry1 = await couch.insertEntry(
+      { $id: null, $content: 'A' },
+      'a@a.com',
+    );
+    const entry2 = await couch.insertEntry(
+      { $id: null, $content: 'B' },
+      'a@a.com',
+    );
+
+    expect(entry1.action).toBe('created');
+    expect(entry2.action).toBe('created');
+    expect(entry1.info.isNew).toBe(true);
+    expect(entry2.info.isNew).toBe(true);
+  });
 });
 
 describe('entry rights', () => {

--- a/test/unit/entry.js
+++ b/test/unit/entry.js
@@ -365,6 +365,15 @@ describe('entry creation and editions', () => {
     expect(entry1.info.isNew).toBe(true);
     expect(entry2.info.isNew).toBe(true);
   });
+
+  test('$id is null by default', async () => {
+    const entry = await couch.insertEntry({ $content: 'A' }, 'a@a.com');
+    expect(entry.action).toEqual('created');
+
+    const dbEntry = await couch.getEntry(entry.info.id, 'a@a.com');
+    expect(dbEntry.$id).toBe(null);
+    expect(dbEntry.$content).toBe('A');
+  });
 });
 
 describe('entry rights', () => {


### PR DESCRIPTION
- fix: allow multiple entries with $id of null to be created
- fix: add doc validation to ensure $id is not undefined
