### PR TITLE
feat: forward skipUserProfile OIDC auth option to passport plugin

### DIFF
--- a/src/server/auth/oidc/index.js
+++ b/src/server/auth/oidc/index.js
@@ -16,6 +16,7 @@ exports.init = function initOidc(passport, router, authConfig, globalConfig) {
         clientID: authConfig.clientID,
         clientSecret: authConfig.clientSecret,
         claims: authConfig.claims,
+        skipUserProfile: authConfig.skipUserProfile,
         callbackURL:
           authConfig.callbackURL ||
           `${globalConfig.publicAddress}/auth/login/oidc/callback`,


### PR DESCRIPTION
Passing `false` will make sure the `userInfo` endpoint is called
