### PR TITLE
feat: give access to couch instance in `getUserInfo` config callback

### DIFF
--- a/src/couch/user.js
+++ b/src/couch/user.js
@@ -74,7 +74,7 @@ const methods = {
     if (!this._config.getUserInfo) {
       throw new CouchError('getUserInfo is not configured', 'bad request');
     }
-    return this._config.getUserInfo(user, ldapSearch);
+    return this._config.getUserInfo(user, ldapSearch, this);
   },
 
   async getUserGroups(user) {

--- a/test/homeDirectories/main/config.js
+++ b/test/homeDirectories/main/config.js
@@ -43,7 +43,8 @@ module.exports = {
     },
     ldap: ldapAuthConfig,
   },
-  async getUserInfo(email, searchLdap) {
+  async getUserInfo(email, searchLdap, couch) {
+    const groups = await couch.getUserGroups(email);
     if (email.endsWith('@zakodium.com')) {
       const uid = email.slice(0, email.indexOf('@'));
       const data = await searchLdap({
@@ -58,6 +59,7 @@ module.exports = {
       return {
         email,
         value: 42,
+        groups,
       };
     }
   },

--- a/test/unit/user.test.js
+++ b/test/unit/user.test.js
@@ -44,7 +44,22 @@ describe('Couch user API', () => {
 
   it('getUserInfo', async () => {
     const user = await couch.getUserInfo('user@test.com');
-    expect(user.email).toBe('user@test.com');
-    expect(user.value).toBe(42);
+    expect(user).toStrictEqual({
+      email: 'user@test.com',
+      value: 42,
+      groups: [],
+    });
+  });
+
+  it('getUserInfo with user which belongs to groups', async () => {
+    const user = await couch.getUserInfo('a@a.com');
+    expect(user).toStrictEqual({
+      email: 'a@a.com',
+      value: 42,
+      groups: [
+        { name: 'groupA', rights: ['create', 'write', 'delete', 'read'] },
+        { name: 'groupB', rights: ['create'] },
+      ],
+    });
   });
 });


### PR DESCRIPTION
This endpoint is typically used to retrieve ldap groups, and this will allow to retrieve user groups which are managed in rest-on-couch
