### PR TITLE
feat: provide session data in getUserInfo callback

### DIFF
--- a/src/couch/user.js
+++ b/src/couch/user.js
@@ -35,14 +35,14 @@ const methods = {
     return getUser(this._db, user);
   },
 
-  getUserInfo(user) {
+  getUserInfo(user, sessionData) {
     debug('getUserInfo (%s)', user);
     // Callback which allows to do a custom ldap search to get user data
     // If it exists, it uses the auth ldap config for default values
     const ldapServer = this._config.auth.ldap?.server;
 
-    function ldapSearch(ldapOptions, searchOptions) {
-      debug('getUserInfo ldapSearch callback');
+    function searchLdap(ldapOptions, searchOptions) {
+      debug('getUserInfo searchLdap callback');
       const defaultLdapOptions = ldapServer
         ? {
             url: ldapServer.url,
@@ -74,7 +74,11 @@ const methods = {
     if (!this._config.getUserInfo) {
       throw new CouchError('getUserInfo is not configured', 'bad request');
     }
-    return this._config.getUserInfo(user, ldapSearch, this);
+    return this._config.getUserInfo(user, {
+      searchLdap,
+      couch: this,
+      sessionData,
+    });
   },
 
   async getUserGroups(user) {

--- a/src/server/middleware/auth.js
+++ b/src/server/middleware/auth.js
@@ -95,6 +95,17 @@ exports.getProfile = function getProfile(ctx) {
   return ctx.session.passport?.user?.profile ?? null;
 };
 
+exports.getSessionData = async function getSessionData(ctx) {
+  const username = await this.getUserEmail(ctx);
+  return {
+    username,
+    admin: this.isAdmin(ctx),
+    provider: this.getProvider(ctx),
+    authenticated: ctx.isAuthenticated(),
+    profile: this.getProfile(ctx),
+  };
+};
+
 async function getUserEmailFromToken(ctx) {
   const config = getGlobalConfig();
   if (!config.authServers.length) return 'anonymous';

--- a/src/server/middleware/couch.js
+++ b/src/server/middleware/couch.js
@@ -271,7 +271,11 @@ exports.editUser = composeWithError(async (ctx) => {
 });
 
 exports.getUserInfo = composeWithError(async (ctx) => {
-  ctx.body = await ctx.state.couch.getUserInfo(ctx.state.userEmail);
+  const sessionData = await auth.getSessionData(ctx);
+  ctx.body = await ctx.state.couch.getUserInfo(
+    ctx.state.userEmail,
+    sessionData,
+  );
 });
 
 exports.getOwners = function getOwners(type) {

--- a/src/server/routes/auth.js
+++ b/src/server/routes/auth.js
@@ -126,11 +126,7 @@ function getAuthRouter() {
     // Check if session exists
     ctx.body = {
       ok: true,
-      username: await auth.getUserEmail(ctx),
-      admin: auth.isAdmin(ctx),
-      provider: auth.getProvider(ctx),
-      authenticated: ctx.isAuthenticated(),
-      profile: auth.getProfile(ctx),
+      ...(await auth.getSessionData(ctx)),
     };
   });
 

--- a/test/homeDirectories/main/config.js
+++ b/test/homeDirectories/main/config.js
@@ -43,7 +43,7 @@ module.exports = {
     },
     ldap: ldapAuthConfig,
   },
-  async getUserInfo(email, searchLdap, couch) {
+  async getUserInfo(email, { searchLdap, couch, sessionData }) {
     const groups = await couch.getUserGroups(email);
     if (email.endsWith('@zakodium.com')) {
       const uid = email.slice(0, email.indexOf('@'));
@@ -54,12 +54,14 @@ module.exports = {
       return {
         email: data[0].object.mail,
         displayName: data[0].object.displayName,
+        sessionData,
       };
     } else {
       return {
         email,
         value: 42,
         groups,
+        sessionData,
       };
     }
   },

--- a/test/unit/rest-api/user.test.js
+++ b/test/unit/rest-api/user.test.js
@@ -119,6 +119,16 @@ describe('LDAP user, developer@zakodium.com', () => {
         expect(res.body).toStrictEqual({
           displayName: 'Developer User',
           email: 'developer@zakodium.com',
+          sessionData: {
+            username: 'developer@zakodium.com',
+            admin: false,
+            provider: 'ldap',
+            authenticated: true,
+            profile: {
+              uid: 'developer',
+              displayName: 'Developer User',
+            },
+          },
         });
       });
   });

--- a/test/unit/user.test.js
+++ b/test/unit/user.test.js
@@ -43,16 +43,17 @@ describe('Couch user API', () => {
   });
 
   it('getUserInfo', async () => {
-    const user = await couch.getUserInfo('user@test.com');
+    const user = await couch.getUserInfo('user@test.com', null);
     expect(user).toStrictEqual({
       email: 'user@test.com',
       value: 42,
       groups: [],
+      sessionData: null,
     });
   });
 
   it('getUserInfo with user which belongs to groups', async () => {
-    const user = await couch.getUserInfo('a@a.com');
+    const user = await couch.getUserInfo('a@a.com', null);
     expect(user).toStrictEqual({
       email: 'a@a.com',
       value: 42,
@@ -60,6 +61,7 @@ describe('Couch user API', () => {
         { name: 'groupA', rights: ['create', 'write', 'delete', 'read'] },
         { name: 'groupB', rights: ['create'] },
       ],
+      sessionData: null,
     });
   });
 });


### PR DESCRIPTION
BREAKING-CHANGE: the callback signature has changed. The first argument is unchanged, but the second argument now contains the couch instance, the searchLdap helper and session data within object properties.
