### PR TITLE
feat: allow iterator symbol in document owners proxy

### DIFF
--- a/src/config/config_proxies.mjs
+++ b/src/config/config_proxies.mjs
@@ -49,4 +49,5 @@ const allowedMethods = [
   'reduce',
   'forEach',
   'push',
+  Symbol.iterator,
 ];

--- a/src/config/config_proxies.mjs
+++ b/src/config/config_proxies.mjs
@@ -1,0 +1,52 @@
+import { isValidOwner } from '../couch/util.js';
+
+export const alterEntryProxyHandler = {
+  get(target, prop) {
+    switch (prop) {
+      case '$content':
+        return target.$content;
+      case '$owners':
+        return new Proxy(target.$owners, alterOwnersProxyHandler);
+      default:
+        throw new Error(`accessing ${prop} is not allowed`);
+    }
+  },
+};
+
+export const alterOwnersProxyHandler = {
+  get(target, prop) {
+    const value = target[prop];
+    if (typeof value === 'function') {
+      if (!allowedMethods.includes(prop)) {
+        throw new Error(`You cannot use ${prop}`);
+      }
+    }
+    return target[prop];
+  },
+  set(target, prop, value) {
+    if (prop === '0') {
+      throw new Error(
+        `You cannot set the first element of $owners (primary user)`,
+      );
+    }
+
+    if (!isValidOwner(value)) {
+      throw new Error(`${value} is not a valid owner`);
+    }
+    target[prop] = value;
+    return true;
+  },
+};
+
+const allowedMethods = [
+  'map',
+  'findIndex',
+  'find',
+  'filter',
+  'every',
+  'includes',
+  'some',
+  'reduce',
+  'forEach',
+  'push',
+];

--- a/src/couch/entry.js
+++ b/src/couch/entry.js
@@ -9,6 +9,7 @@ const ensureStringArray = require('../util/ensureStringArray');
 const nanoMethods = require('./nano');
 const util = require('./util');
 const validateMethods = require('./validate');
+const { alterEntryProxyHandler } = require('../config/config_proxies.mjs');
 
 const methods = {
   async getEntryWithRights(uuid, user, rights, options = {}) {
@@ -476,53 +477,3 @@ function lockify(fun, getKey) {
     return result;
   };
 }
-
-const alterEntryProxyHandler = {
-  get(target, prop) {
-    switch (prop) {
-      case '$content':
-        return target.$content;
-      case '$owners':
-        return new Proxy(target.$owners, alterOwnersProxyHandler);
-      default:
-        throw new Error(`altering ${prop} is not allowed`);
-    }
-  },
-};
-
-const allowedMethods = [
-  'map',
-  'findIndex',
-  'find',
-  'filter',
-  'every',
-  'includes',
-  'some',
-  'reduce',
-  'forEach',
-  'push',
-];
-const alterOwnersProxyHandler = {
-  get(target, prop) {
-    const value = target[prop];
-    if (typeof value === 'function') {
-      if (!allowedMethods.includes(prop)) {
-        throw new Error(`You cannot use ${prop}`);
-      }
-    }
-    return target[prop];
-  },
-  set(target, prop, value) {
-    if (prop === '0') {
-      throw new Error(
-        `You cannot set the first element of $owners (primary user)`,
-      );
-    }
-
-    if (!util.isValidOwner(value)) {
-      throw new Error(`${value} is not a valid owner`);
-    }
-    target[prop] = value;
-    return true;
-  },
-};

--- a/test/homeDirectories/main/config.js
+++ b/test/homeDirectories/main/config.js
@@ -73,6 +73,7 @@ module.exports = {
   },
   beforeCreateHook(document, groups) {
     const owner = document.$owners[0];
+
     const groupsToAdd = groups.filter(
       (group) =>
         !document.$owners.some((owner) => owner === group.name) &&

--- a/test/unit/config/config_proxies.test.js
+++ b/test/unit/config/config_proxies.test.js
@@ -65,6 +65,15 @@ describe('Accessing and mutating $owners', () => {
     expect(proxied.$owners.length).toBe(2);
   });
 
+  it('can iterate over $owners with the iterator', () => {
+    const proxied = createProxy();
+    let charCount = 0;
+    for (let owner of proxied.$owners) {
+      charCount += owner.length;
+    }
+    expect(charCount).toBe(28);
+  });
+
   it('cannot mutate primary owner', () => {
     const proxied = createProxy();
 

--- a/test/unit/config/config_proxies.test.js
+++ b/test/unit/config/config_proxies.test.js
@@ -54,6 +54,20 @@ describe('Accessing and mutating $owners', () => {
     expect(proxied.$owners[1]).toBe('other_group');
   });
 
+  it('validates mutated group', () => {
+    const proxied = createProxy();
+    expect(() => {
+      proxied.$owners[1] = 'new+group';
+    }).toThrow('new+group is not a valid owner');
+  });
+
+  it('validates added group', () => {
+    const proxied = createProxy();
+    expect(() => {
+      proxied.$owners.push('new+group');
+    }).toThrow('new+group is not a valid owner');
+  });
+
   it('can add group', () => {
     const proxied = createProxy();
     proxied.$owners.push('new_group');

--- a/test/unit/config/config_proxies.test.js
+++ b/test/unit/config/config_proxies.test.js
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test';
+import { expect } from 'chai';
+import { alterEntryProxyHandler } from '../../../src/config/config_proxies.mjs';
+
+const testEntry = {
+  _id: 'test',
+  _rev: '1-test',
+  $content: {
+    arr: [1, 2, 3],
+    a: {
+      b: 'ok',
+    },
+  },
+  $owners: ['admin@cheminfo.org', 'test-group'],
+};
+describe('Accessing private properties', () => {
+  const privateProperties = ['_id', '_rev'];
+  for (const prop of privateProperties) {
+    it(`${prop} cannot be accessed`, () => {
+      const proxied = createProxy();
+      expect(() => proxied[prop]).toThrow(`accessing ${prop} is not allowed`);
+    });
+  }
+});
+
+describe('Accessing and mutating $content', () => {
+  it('can read nested $content properties', () => {
+    const proxied = createProxy();
+    expect(proxied.$content.a.b).toBe('ok');
+    expect(proxied.$content.arr[1]).toBe(2);
+  });
+
+  it('can mutate nested $content properties', () => {
+    const proxied = createProxy();
+
+    proxied.$content.a.b = 'changed';
+    proxied.$content.arr[1] = 42;
+    expect(proxied.$content.a.b).toBe('changed');
+    expect(proxied.$content.arr[1]).toBe(42);
+  });
+});
+
+describe('Accessing and mutating $owners', () => {
+  it('can read $owners', () => {
+    const proxied = createProxy();
+
+    const firstOwner = proxied.$owners[0];
+    expect(firstOwner).toBe('admin@cheminfo.org');
+  });
+
+  it('can mutate group', () => {
+    const proxied = createProxy();
+    proxied.$owners[1] = 'other_group';
+    expect(proxied.$owners[1]).toBe('other_group');
+  });
+
+  it('can add group', () => {
+    const proxied = createProxy();
+    proxied.$owners.push('new_group');
+    expect(proxied.$owners[2]).toBe('new_group');
+  });
+
+  it('can access length property', () => {
+    const proxied = createProxy();
+    expect(proxied.$owners.length).toBe(2);
+  });
+
+  it('cannot mutate primary owner', () => {
+    const proxied = createProxy();
+
+    expect(() => {
+      proxied.$owners[0] = 'new_owner@cheminfo.org';
+    }).toThrow('You cannot set the first element of $owners (primary user)');
+  });
+});
+
+function createProxy() {
+  return new Proxy(structuredClone(testEntry), alterEntryProxyHandler);
+}


### PR DESCRIPTION
Closes: https://github.com/cheminfo/rest-on-couch/issues/528

- **tests: put config proxy implementation in separate file and add tests for it**
- **fix: allow to iterate using iterator in config hook proxy**
