### PR TITLE
fix: add path validation in server.js

### DIFF
--- a/src/file-drop/server.js
+++ b/src/file-drop/server.js
@@ -32,13 +32,29 @@ router.get('/', (ctx) => {
   ctx.status = 200;
 });
 
+function toSafeName(value) {
+  const name = path.basename(String(value ?? ''));
+  if (!name || name === '.' || name === '..') {
+    return null;
+  }
+  return name;
+}
+
 async function writeUpload(ctx, database, kind, filename) {
-  const dir = path.join(ctx.state.homeDir, database, kind, 'to_process');
-  const tmpDir = path.join(ctx.state.homeDir, database, kind, 'tmp');
+  const safeDatabase = toSafeName(database);
+  const safeKind = toSafeName(kind);
+  const safeFilename = toSafeName(filename);
+  if (!safeDatabase || !safeKind || !safeFilename) {
+    ctx.body = 'Invalid path parameter';
+    ctx.status = 400;
+    return;
+  }
+  const dir = path.join(ctx.state.homeDir, safeDatabase, safeKind, 'to_process');
+  const tmpDir = path.join(ctx.state.homeDir, safeDatabase, safeKind, 'tmp');
   await fs.mkdir(tmpDir, { recursive: true });
   const uploadDir = await fs.mkdtemp(path.join(tmpDir, 'roc-upload-'));
-  const uploadPath = path.join(uploadDir, filename);
-  const file = path.join(dir, filename);
+  const uploadPath = path.join(uploadDir, safeFilename);
+  const file = path.join(dir, safeFilename);
   const write = createWriteStream(uploadPath);
   try {
     await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/file-drop/server.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/file-drop/server.js:73` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-22 |

**Description**: The file upload endpoint accepts user-controlled filename parameter without sanitization. The filename is directly used in file path construction, allowing path traversal sequences (e.g., '../../../etc/cron.d/backdoor') to write files outside the intended upload directory.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `src/file-drop/server.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
